### PR TITLE
Fix download of images from Nextcloud

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ deploy: clean images
 
 #.PHONY: images
 #images:
-#	curl $(IMAGES_URL) -o $(IMAGES_ARCHIVE)
+#	curl -L $(IMAGES_URL) -o $(IMAGES_ARCHIVE)
 #	unzip -j -o $(IMAGES_ARCHIVE) -d $(IMAGES_DIR)
 #	rm -f $(IMAGES_ARCHIVE)
 


### PR DESCRIPTION
Solution was to add the `-L` flag with `curl` to follow redirects.

This PR only adds the -L flag, the `make images` command is still disabled by the comments in the Makefile.

From here you could either:

1. Continue committing image files into Git directly and ignore the download from Nextcloud (easy and does not hurt if the amount of images grows too much)
2. Start adding images to Nextcloud again but keeping committed images in history (also fine, does not seem to interfere but might add some confusion which workflow is used for images)
3. Continue using the Nextcloud pipeline again and removing all committed images from history ("cleanest" variant IMO, but depending on how you committed the images could be tedious to remove them from history)

Fixes #61 